### PR TITLE
Attach all event handlers to body instead of step element

### DIFF
--- a/src/enjoyhint.js
+++ b/src/enjoyhint.js
@@ -155,7 +155,7 @@ var EnjoyHint = function (_options) {
                         }
 
                     } else {
-                        $event_element.on(event, function (e) {
+                        $body.on(event, step_data.selector, function (e) {
                             if (step_data.keyCode && e.keyCode != step_data.keyCode) {
                                 return;
                             }


### PR DESCRIPTION
This allows events like dragstart to work.
{ 'dragstart .drag-obj’: ‘Drag me to …' }
